### PR TITLE
fix(release): only include files from `dist`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Thoralf Thelle <thoralf@dintero.com>",
   "license": "MIT",
   "private": false,
+  "files": ["/dist"],
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",


### PR DESCRIPTION
Add `dist` folder to the list of files to include when creating a package
