### PR TITLE
feat(validation): support suggesting TLDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,6 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/__tests__/check-tld.test.ts
+++ b/src/__tests__/check-tld.test.ts
@@ -1,0 +1,15 @@
+import { checkTLD } from '../utils';
+
+describe(checkTLD, () => {
+    it('should suggest a TLD at the end if it does not exist in the array', () => {
+        const tlds = ['com', 'net', 'org'];
+        expect(checkTLD('test@gmail.com', tlds)).toBe(''); // valid, no suggestion
+        expect(checkTLD('test@gmail.co', tlds)).toBe('test@gmail.co.com');
+        expect(checkTLD('test@gmail.nee', tlds)).toBe('test@gmail.nee.com');
+        expect(checkTLD('test@gmail.net', tlds)).toBe(''); // valid, no suggestion
+        expect(checkTLD('test@gmail.og', tlds)).toBe('test@gmail.og.com');
+        expect(checkTLD('test@gmail.org', tlds)).toBe(''); // valid, no suggestion
+        expect(checkTLD('test@skola.goteborg', tlds)).toBe('test@skola.goteborg.com');
+        expect(checkTLD('test@oslo.kommune', tlds)).toBe('test@oslo.kommune.com');
+    });
+});

--- a/src/__tests__/email-chk.test.ts
+++ b/src/__tests__/email-chk.test.ts
@@ -116,13 +116,13 @@ describe(EmailChk, () => {
         })).toBe('test@dintero.com');
     });
 
-    it('should use tlds when validating email', () => {
+    it('should run the checkTLD call when tld list is defined in consumer', () => {
         const emailChk = EmailChk();
-        expect(emailChk('test@skola.goteborg')).toBe('test@skola.com');
-        expect(emailChk('test@skola.se')).toBe('');
-        expect(emailChk('test@gmail.se')).toBe('test@gmail.com');
-        expect(emailChk('test@dintero.co.uk')).toBe('test@dintero.dk');
-        expect(emailChk('test@netto.finland')).toBe('test@netto.fi');
-        expect(emailChk('test@checkout.dintero')).toBe('test@checkout.no');
+        expect(emailChk('test@arbitrary.long.domain', {
+            checkMissingTLD: ['com'],
+        })).toBe('test@arbitrary.long.domain.com');
+        expect(emailChk('test@oslo.kommune', {
+            checkMissingTLD: ['no'],
+        })).toBe('test@oslo.kommune.no');
     });
 });

--- a/src/__tests__/email-chk.test.ts
+++ b/src/__tests__/email-chk.test.ts
@@ -24,6 +24,8 @@ describe(EmailChk, () => {
         expect(emailChk('test@gmael.com')).toBe('test@gmail.com');
         expect(emailChk('test@gmaild.com')).toBe('test@gmail.com');
         expect(emailChk('test@ggmail.com')).toBe('test@gmail.com');
+        expect(emailChk('something@gmail.comk')).toBe('something@gmail.com');
+        expect(emailChk('something@gamil.com')).toBe('something@gmail.com');
     });
 
     it('should suggest hotmail when any hotmail typo is inputted', () => {
@@ -90,6 +92,7 @@ describe(EmailChk, () => {
         expect(emailChk('test@onlin.no')).toBe('test@online.no');
         expect(emailChk('test@onlive.nm')).toBe('test@online.no');
         expect(emailChk('test@onlien.nio')).toBe('test@online.no');
+        expect(emailChk('test@onlie.no')).toBe('test@online.no');
     });
 
     it('should make use of only set config', () => {
@@ -111,5 +114,15 @@ describe(EmailChk, () => {
         expect(emailChk('test@diner.com', {
             website: 'https://www.dintero.com',
         })).toBe('test@dintero.com');
+    });
+
+    it('should use tlds when validating email', () => {
+        const emailChk = EmailChk();
+        expect(emailChk('test@skola.goteborg')).toBe('test@skola.com');
+        expect(emailChk('test@skola.se')).toBe('');
+        expect(emailChk('test@gmail.se')).toBe('test@gmail.com');
+        expect(emailChk('test@dintero.co.uk')).toBe('test@dintero.dk');
+        expect(emailChk('test@netto.finland')).toBe('test@netto.fi');
+        expect(emailChk('test@checkout.dintero')).toBe('test@checkout.no');
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { closestMatchTLD, getDomain, getTLD, levenstein, validateTLD } from './utils';
+import { checkTLD, getDomain, levenstein } from './utils';
 
 /**
  * @typedef {string} EmailDomain
@@ -29,10 +29,12 @@ export type SuggestionMetric = {
 /**
  * @typedef {Object} CheckOptions
  * @property {string} [website] - Website to check against
+ * @property {string[]} [checkMissingTLD] - List of TLDs to check against, enabled if defined
  * Options for the EmailChk consumer function
  */
 export type CheckOptions = {
     website?: string
+    checkMissingTLD?: string[]
 }
 
 
@@ -48,14 +50,6 @@ const defaultConfig = {
         'online.no',
     ],
     levensteinThreshold: 3,
-    tlds: [
-        'com',
-        'no',
-        'se',
-        'dk',
-        'fi',
-        'de',
-    ]
 };
 
 /**
@@ -96,16 +90,12 @@ export const EmailChk = (configuration?: EmailChkConfig) => {
             return `${username}@${suggestion.suggestedDomain}`;
         }
 
-        const tld = getTLD(domain);
-        if (!tld) {
-            return `${username}@${domain.split('.')[0]}.${config.tlds[0]}`;
-        }
-
-        if (!validateTLD(tld, config.tlds)) {
-            return `${username}@${domain.split('.')[0]}.${closestMatchTLD(tld, config.tlds)}`;
+        if (opt && opt.checkMissingTLD) {
+            return checkTLD(email, opt.checkMissingTLD);
         }
 
         return '';
     };
 };
+
 export default EmailChk;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,22 +75,34 @@ export const getTLD = (domain?: string): string | undefined => {
     }
     try {
         const parts = domain.split('.');
-        return parts[parts.length - 1];
+        return [...parts].slice(1).join('.');
     } catch (error) {
         throw error;
     }
 };
 
 export const validateTLD = (tld: string, validTlds: string[]): boolean => {
-    return validTlds.indexOf(tld) > -1;
+    return tld.split('.').reduce<boolean>((acc, tldPart) => {
+        return acc && validTlds.indexOf(tldPart) > -1;
+    }, true);
 };
 
-export const closestMatchTLD = (tld: string, validTlds: string[]): string => {
-    return validTlds.reduce<string>((acc, validTld) => {
-        const dist = levenstein(tld, validTld);
-        if (dist < levenstein(acc, tld)) {
-            return validTld;
-        }
-        return acc;
-    }, validTlds[0]);
+/**
+ * Check if the last part of the domain is missing a TLD
+ * @param email Email address
+ * @param validTlds List of TLDs to check against
+ * @returns Suggested email address with valid TLD if there's missing a TLD
+ */
+export const checkTLD = (email: string, tlds: string[]): string => {
+    const [username, domain] = email.split('@');
+    const tld = getTLD(domain);
+    if (!tld) {
+        return `${username}@${domain.split('.')[0]}.${tlds[0]}`;
+    }
+
+    if (!validateTLD(tld, tlds)) {
+        return `${username}@${domain}.${tlds[0]}`;
+    }
+
+    return '';
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,3 +68,29 @@ export const getDomain = (website?: string): string | undefined => {
         throw error;
     }
 };
+
+export const getTLD = (domain?: string): string | undefined => {
+    if (!domain) {
+        return;
+    }
+    try {
+        const parts = domain.split('.');
+        return parts[parts.length - 1];
+    } catch (error) {
+        throw error;
+    }
+};
+
+export const validateTLD = (tld: string, validTlds: string[]): boolean => {
+    return validTlds.indexOf(tld) > -1;
+};
+
+export const closestMatchTLD = (tld: string, validTlds: string[]): string => {
+    return validTlds.reduce<string>((acc, validTld) => {
+        const dist = levenstein(tld, validTld);
+        if (dist < levenstein(acc, tld)) {
+            return validTld;
+        }
+        return acc;
+    }, validTlds[0]);
+};


### PR DESCRIPTION
- Validate if the TLD in the domain exists and if it matches one of the predefined valid TLDs
- If not suggest the default ".com" or closest possible match using the same algorithm for domains