### PR TITLE
chore(release): Fix repository URL format

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "eslint": "^8.34.0",
-    "eslint-config-dintero": "https://github.com/Dintero/eslint-config-dintero",
+    "eslint-config-dintero": "git+https://github.com/Dintero/eslint-config-dintero.git",
     "jest": "^30.0.4",
     "semantic-release": "25.0.1",
     "ts-jest": "^29.0.5",
@@ -44,7 +44,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Dintero/email-chk"
+    "url": "git+https://github.com/Dintero/email-chk.git"
   },
   "homepage": "https://github.com/Dintero/email-chk",
   "bugs": {


### PR DESCRIPTION
Release using npm OICD worked, but the release build failed
because of error in the @semantic-release/github plugin

> semantic-release: TypeError: Cannot destructure property 'repository' of

Rel: https://github.com/Dintero/email-chk/actions/runs/18689723873/job/53293181533
Fixes: https://github.com/Dintero/email-chk/issues/201
