### PR TITLE
feat(multi-tld): support multi-part TLDs like co.uk

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,24 @@ const emailChk = EmailChk({
 const email = "username@gmain.com";
 const result = emailChk(email); // username@gmail.com
 ```
+TLD checking with `checkMissingTLD`:
+```ts
+import { EmailChk } from '@dintero/email-chk';
+
+const emailChk = EmailChk();
+
+// Suggests a TLD when one is missing or unrecognised
+emailChk('username@example', { checkMissingTLD: ['com'] });
+// → username@example.com
+
+// Supports multi-part TLDs such as co.uk
+emailChk('username@example.co', { checkMissingTLD: ['co.uk'] });
+// → username@example.co.uk
+
+// Known providers are resolved to their correct domain instead
+emailChk('username@gmail.co', { checkMissingTLD: ['co.uk'] });
+// → username@gmail.com  (gmail is in the default domains list)
+```
 React:
 ```tsx
 import { EmailChk } from '@dintero/email-chk';

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ export const EmailChk = (configuration?: EmailChkConfig) => {
         }
 
         if (opt?.checkMissingTLD) {
-            return checkTLD(email, opt.checkMissingTLD);
+            return checkTLD(email, opt.checkMissingTLD, config.domains);
         }
 
         return "";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,27 +72,50 @@ export const getTLD = (domain?: string): string | undefined => {
 };
 
 export const validateTLD = (tld: string, validTlds: string[]): boolean => {
-    return tld.split(".").reduce<boolean>((acc, tldPart) => {
-        return acc && validTlds.indexOf(tldPart) > -1;
-    }, true);
+    return validTlds.indexOf(tld) > -1;
 };
 
 /**
  * Check if the last part of the domain is missing a TLD
  * @param email Email address
- * @param validTlds List of TLDs to check against
+ * @param tlds List of TLDs to check against
+ * @param knownDomains Optional list of known email domains (e.g. ["gmail.com"]) used to
+ *   avoid incorrect multi-part TLD completions for well-known providers
  * @returns Suggested email address with valid TLD if there's missing a TLD
  */
-export const checkTLD = (email: string, tlds: string[]): string => {
+export const checkTLD = (
+    email: string,
+    tlds: string[],
+    knownDomains: string[] = [],
+): string => {
     const [username, domain] = email.split("@");
     const tld = getTLD(domain);
+    const domainBase = domain.split(".")[0];
+
     if (!tld) {
-        return `${username}@${domain.split(".")[0]}.${tlds[0]}`;
+        return `${username}@${domainBase}.${tlds[0]}`;
     }
 
-    if (!validateTLD(tld, tlds)) {
-        return `${username}@${domain}.${tlds[0]}`;
+    if (validateTLD(tld, tlds)) {
+        return "";
     }
 
-    return "";
+    // If the base name matches a known provider, suggest that known domain rather than
+    // a multi-part TLD completion (e.g. gmail.co → gmail.com, not gmail.co.uk).
+    const knownDomain = knownDomains.find(
+        (d) => d.split(".")[0] === domainBase,
+    );
+    if (knownDomain) {
+        return `${username}@${knownDomain}`;
+    }
+
+    // If the current TLD is a leading segment of a valid multi-part TLD, replace it.
+    // e.g. tld="co" with tlds=["co.uk"] → strip "co", prepend "co.uk".
+    const partialMatch = tlds.find((t) => t.startsWith(`${tld}.`));
+    if (partialMatch) {
+        const base = domain.slice(0, domain.length - tld.length - 1);
+        return `${username}@${base}.${partialMatch}`;
+    }
+
+    return `${username}@${domain}.${tlds[0]}`;
 };

--- a/test/check-tld.test.ts
+++ b/test/check-tld.test.ts
@@ -20,4 +20,49 @@ describe(checkTLD.name, () => {
             "test@oslo.kommune.com",
         );
     });
+
+    test("should correctly handle multi-part TLDs", () => {
+        const tlds = ["co.uk", "com.au", "org.uk", "com"];
+
+        // Valid multi-part TLD → no suggestion
+        assert.equal(checkTLD("test@bbc.co.uk", tlds), "");
+        assert.equal(checkTLD("test@example.com.au", tlds), "");
+        assert.equal(checkTLD("test@example.org.uk", tlds), "");
+
+        // Valid single-part TLD in the same list → no suggestion
+        assert.equal(checkTLD("test@gmail.com", tlds), "");
+
+        // Partial leading segment → replace with full multi-part TLD
+        assert.equal(
+            checkTLD("test@person.co", ["co.uk"]),
+            "test@person.co.uk",
+        );
+        assert.equal(
+            checkTLD("test@example.com", ["com.au"]),
+            "test@example.com.au",
+        );
+        assert.equal(
+            checkTLD("test@example.org", ["org.uk"]),
+            "test@example.org.uk",
+        );
+
+        // Known provider with partial segment → use known domain, not co.uk
+        assert.equal(
+            checkTLD("test@gmail.co", ["co.uk"], ["gmail.com", "yahoo.com"]),
+            "test@gmail.com",
+        );
+        assert.equal(
+            checkTLD("test@yahoo.co", ["co.uk"], ["gmail.com", "yahoo.com"]),
+            "test@yahoo.com",
+        );
+
+        // No partial match → fall back to appending tlds[0]
+        assert.equal(
+            checkTLD("test@example.xyz", ["co.uk", "com"]),
+            "test@example.xyz.co.uk",
+        );
+
+        // No TLD at all with a multi-part TLD list
+        assert.equal(checkTLD("test@example", ["co.uk"]), "test@example.co.uk");
+    });
 });


### PR DESCRIPTION
validateTLD now matches the full TLD string directly instead of
checking each dot-separated segment individually. checkTLD gains
an optional knownDomains parameter to avoid spurious multi-part
completions for well-known providers (e.g. gmail.co → gmail.com,
not gmail.co.uk). EmailChk passes config.domains through.

Fixes https://github.com/Dintero/email-chk/issues/136
